### PR TITLE
Add reason and headers

### DIFF
--- a/src/RedirectHistory.php
+++ b/src/RedirectHistory.php
@@ -6,9 +6,9 @@ class RedirectHistory
 {
     protected array $history = [];
 
-    public function add(int $status, string $url)
+    public function add(int $status, string $url, string $reason, array $headers)
     {
-        $this->history[] = compact('status', 'url');
+        $this->history[] = compact('status', 'url', 'reason', 'headers');
     }
 
     public function toArray(): array

--- a/src/RedirectHistoryMiddleware.php
+++ b/src/RedirectHistoryMiddleware.php
@@ -25,7 +25,9 @@ class RedirectHistoryMiddleware
             $response->then(function (ResponseInterface $response) use ($request) {
                 $this->redirectHistory->add(
                     $response->getStatusCode(),
-                    (string)$request->getUri()
+                    (string)$request->getUri(),
+                    $response->getReasonPhrase(),
+                    $response->getHeaders()
                 );
             });
 


### PR DESCRIPTION
When reading the redirect chain I needed more details such as headers.

Since Guzzle already manages the reason (so as to explain the status code) and the headers of each request, I made a small change to the middleware to add this information.

They could be useful to others, they are not blockers, I thought about doing the PR.